### PR TITLE
Added a setting to let the cover show the current HungerMeter's battery percentage

### DIFF
--- a/qml/CoverPage.qml
+++ b/qml/CoverPage.qml
@@ -23,6 +23,7 @@ import Sailfish.Silica 1.0
 
 CoverBackground {
     id: coverPage
+
     Timer {
         id: pageTimer
         interval: 1000;
@@ -69,17 +70,30 @@ CoverBackground {
             font.pixelSize: Theme.fontSizeLarge
         }
         Label {
-            text: (app.show_int?"":qsTr("Long ")) + qsTr("Avg") + (app.show_int?(" (" + app.long_avg + " h):"):":")
+            text: {
+                if(percOnCover == false) {
+                    (app.show_int?"":qsTr("Long ")) + qsTr("Avg") + (app.show_int?(" (" + app.long_avg + " h):"):":")
+                } else {
+                    "Battery:"
+                }
+            }
+
             width: parent.width
             color: Theme.secondaryColor
             horizontalAlignment: Text.AlignLeft
             font.pixelSize: Theme.fontSizeMedium
         }
         Label {
-            id: coverLongText
             width: parent.width
             horizontalAlignment: Text.AlignRight
-            text: ""
+            text: {
+                if(percOnCover == false) {
+                    hunger.long_text()
+                } else {
+                    hunger.bat_cur_pr()
+                }
+            }
+
             font.pixelSize: Theme.fontSizeLarge
         }
     }

--- a/qml/Settings.qml
+++ b/qml/Settings.qml
@@ -179,6 +179,16 @@ Page {
                     settings.setValue("persistent", checked?1:0);
                 }
             }
+            TextSwitch {
+                id: percOnCover
+                text: qsTr("Percentage on cover")
+                description: qsTr("Show HungerMeter's battery percentage on the app cover.")
+                checked: app.percOnCover
+                onCheckedChanged: {
+                    app.percOnCover = checked
+                    settings.setValue("percOnCover", checked?1:0);
+                }
+            }
         }
     }
 }

--- a/qml/harbour-hungermeter.qml
+++ b/qml/harbour-hungermeter.qml
@@ -32,6 +32,7 @@ ApplicationWindow
     property int long_time: settings.value("long_time",   5)
     property int long_avg:  settings.value("long_avg",   24)
     property bool show_int: settings.value("show_int",    1)>0
+    property bool percOnCover: settings.value("percOnCover",    1)>0
     Hunger {
         id: hunger
     }


### PR DESCRIPTION
Can be very useful for a lot of people, and leaves the standard behaviour of the application intact: toggle this mode in _Settings --> Percentage on cover_.
